### PR TITLE
Corrected `hic` indexes

### DIFF
--- a/snippets/html-import-polymer-element.cson
+++ b/snippets/html-import-polymer-element.cson
@@ -2,5 +2,5 @@
   "import core-element":
     "prefix": "hic"
     "body": """
-    <link rel="import" href="${1:bower_components}/core-$1/core-$1.html">
+    <link rel="import" href="${1:bower_components}/core-$2/core-$2.html">
     """


### PR DESCRIPTION
This fixes the issue with `bower_components` and `core-`_element-name_ being replaced with the same string. Now you can tab between the two as intended.

Compare this to `hip` which has been working correctly.
