### PR TITLE
fix Uncaught SyntaxError: Unexpected token ILLEGAL in Polymer page template

### DIFF
--- a/snippets/html.cson
+++ b/snippets/html.cson
@@ -31,7 +31,7 @@
           && 'content' in document.createElement('template')) {
             // Native WC support. Do nothing
           } else {
-            document.write('<script src="/bower_components/webcomponentsjs/webcomponents.js"><\/script>');
+            document.write('<script src="/bower_components/webcomponentsjs/webcomponents.js"><\\/script>');
           }
         </script>
       </head>


### PR DESCRIPTION
In reference to #3, which doesn't actually fix the issue.

The backslash must be escaped in order for it to appear in the HTML generated by the snippet.

The following variant may also be used according to [the answer to Why split the <script> tag when writing it with document.write()?](http://stackoverflow.com/a/236106/164430):

``` javascript
document.write('\\x3Cscript src="/bower_components/webcomponentsjs/webcomponents.js">\\x3C/script>');
```

Note that the backslashes are still escaped within the snippet body, and are unescaped when inserted into the code.
