### PR TITLE
Fix activation events

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
       "email": "mateus.prado@ig.com.br"
     }
   ],
-  "activationEvents": [
-    "polymer-snippets:toggle"
-  ],
+  "activationCommands": {
+    "atom-text-editor": ["polymer-snippets:toggle"]
+  },
   "repository": "https://github.com/robdodson/atom-PolymerSnippets",
   "license": "MIT",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "repository": "https://github.com/robdodson/atom-PolymerSnippets",
   "license": "MIT",
   "engines": {
-    "atom": ">0.50.0"
+    "atom": ">0.199.0"
   },
   "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "polymer-snippets",
   "main": "./lib/polymer-snippets",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Polymer Snippets for Atom",
   "author": {
     "name": "Rob Dodson",


### PR DESCRIPTION
Fixes the deprecation error warning. Package will now continue to work when Atom version 1.0 is released in June. I assume that there will probably be an updated version of this package for Polymer 1.0 that will released before then, but for now this gets rid of the annoying error message.

Version number bumped to 1.1.3

---

Use `activationCommands` instead of `activationEvents` in your package.json
Commands should be grouped by selector as follows:

``` json
  "activationCommands": {
    "atom-workspace": ["foo:bar", "foo:baz"],
    "atom-text-editor": ["foo:quux"]
  }
```

```
Package.getActivationCommands (/Applications/Atom.app/Contents/Resources/app.asar/src/package.js:808:9)
Package.hasActivationCommands (/Applications/Atom.app/Contents/Resources/app.asar/src/package.js:733:20)
<unknown> (/Applications/Atom.app/Contents/Resources/app.asar/src/package.js:185:24)
Package.measure (/Applications/Atom.app/Contents/Resources/app.asar/src/package.js:163:15)
Package.load (/Applications/Atom.app/Contents/Resources/app.asar/src/package.js:177:12)
PackageManager.loadPackage (/Applications/Atom.app/Contents/Resources/app.asar/src/package-manager.js:355:14)
```
