### PR TITLE
activationEvents -> activationCommands

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
       "email": "mateus.prado@ig.com.br"
     }
   ],
-  "activationEvents": [
+  "activationCommands": [
     "polymer-snippets:toggle"
   ],
   "repository": "https://github.com/robdodson/atom-PolymerSnippets",


### PR DESCRIPTION
Package.getActivationCommands is deprecated.
Use `activationCommands` instead of `activationEvents`.
