### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![banner](http://s12.postimg.org/opgzpvtpp/banner.png)
 
 ## Install
-Go to `atom > Preferences...` then search for Polymer Snippets in Packages tab.
+Go to `atom > Preferences...` then search for Polymer Snippets in the `Install` tab.
 
 ## Compatibility with Emmet
 If you have [Emmet](https://github.com/emmetio/emmet-atom) installed it will clobber the tab completion for HTML snippets. You can follow [this workaround](https://github.com/emmetio/emmet-atom/issues/225#issuecomment-82669798) to get Polymer snippets working again.


### PR DESCRIPTION
It's unclear when this changed, but in my latest Atom, the `Packages` tab lists the installed packages, and the `Install` tab lets you install new ones. Updating the readme to reflect this. 
