### PR TITLE
Give dom-repeat a context

### DIFF
--- a/snippets/dom-repeat.cson
+++ b/snippets/dom-repeat.cson
@@ -1,4 +1,5 @@
-"dom-repeat":
+".text.html":
+  "dom-repeat":
     "prefix": "dom-repeat"
     "body": """
     <template is="dom-repeat" items="$1"${2: index-as="index"}>$0</template>


### PR DESCRIPTION
The `dom-repeat` snippet doesn't have a context and so it isn't working. This PR fixes that.
