### PR TITLE
Add snippet for iron-jsonp-library

### DIFF
--- a/snippets/iron-jsonp-library.cson
+++ b/snippets/iron-jsonp-library.cson
@@ -1,0 +1,9 @@
+".text.html":
+  "iron jsonp library":
+    "prefix": "iron-jsonp-library"
+    "body": """
+    <iron-jsonp-library
+      library-url="${1}"
+      notify-event="${2}"
+      library-loaded="${3}"></iron-jsonp-library>
+    """


### PR DESCRIPTION
Adding cson file for including snippet for iron-jsonp-library.

Snippet will generate the following text:

<iron-jsonp-library
  library-url=""
  notify-event=""
  library-loaded=""></iron-jsonp-library>
