### PR TITLE
Add anchor points for tabbing after element declaration

### DIFF
--- a/snippets/custom-style.cson
+++ b/snippets/custom-style.cson
@@ -2,5 +2,6 @@
   "Polymer custom-style":
     "prefix": "pcs"
     "body": """
-    <style ${1:is="custom-style"} include="${0:shared-styles}"></style>
+    <style ${1:is="custom-style"} include="${2:shared-styles}"></style>
+    $0
     """

--- a/snippets/dom-if.cson
+++ b/snippets/dom-if.cson
@@ -2,5 +2,7 @@
   "dom-if":
     "prefix": "dom-if"
     "body": """
-    <template is="dom-if" if="$1"${2: restamp="true"}>$0</template>
+    <template is="dom-if" if="$1"${2: restamp="true"}>
+      $0
+    </template>
     """

--- a/snippets/dom-repeat.cson
+++ b/snippets/dom-repeat.cson
@@ -2,5 +2,7 @@
   "dom-repeat":
     "prefix": "dom-repeat"
     "body": """
-    <template is="dom-repeat" items="$1"${2: index-as="index"}>$0</template>
+    <template is="dom-repeat" items="$1"${2: index-as="index"}>
+      $0
+    </template>
     """

--- a/snippets/html-import-iron-element.cson
+++ b/snippets/html-import-iron-element.cson
@@ -3,4 +3,5 @@
     "prefix": "hii"
     "body": """
     <link rel="import" href="${1:bower_components}/iron-$2/iron-$2.html">
+    $0
     """

--- a/snippets/html-import-paper-element.cson
+++ b/snippets/html-import-paper-element.cson
@@ -3,4 +3,5 @@
     "prefix": "hip"
     "body": """
     <link rel="import" href="${1:bower_components}/paper-$2/paper-$2.html">
+    $0
     """

--- a/snippets/html-import.cson
+++ b/snippets/html-import.cson
@@ -2,5 +2,6 @@
   "html import":
     "prefix": "hi"
     "body": """
-    <link rel="import" href="${1:bower_components}/${0}/${0}.html">
+    <link rel="import" href="${1:bower_components}/${2}/${2}.html">
+    $0
     """

--- a/snippets/iron-a11y-keys.cson
+++ b/snippets/iron-a11y-keys.cson
@@ -2,5 +2,6 @@
   "iron a11y keys":
     "prefix": "iron-a11y-keys"
     "body": """
-    <iron-a11y-keys target="${1:\{\{\}\}}" keys="${2:up down left right}" on-keys-pressed="{{${3:arrowHandler}}}"></iron-a11y-keys>
+    <iron-a11y-keys target="${1:\\{\\{${2}\\}\\}}" keys="${3:up down left right}" on-keys-pressed="{{${4:arrowHandler}}}"></iron-a11y-keys>
+    $0
     """

--- a/snippets/iron-ajax.cson
+++ b/snippets/iron-ajax.cson
@@ -7,4 +7,5 @@
       url="${2}"
       handle-as="${3:json}"
       on-response="${4:handleResponse}"></iron-ajax>
+    $0
     """

--- a/snippets/iron-collapse.cson
+++ b/snippets/iron-collapse.cson
@@ -3,6 +3,6 @@
     "prefix": "iron-collapse"
     "body": """
     <iron-collapse id="${1:collapse}">
-      Content goes here...
+      $0
     </iron-collapse>
     """

--- a/snippets/iron-doc-viewer.cson
+++ b/snippets/iron-doc-viewer.cson
@@ -3,4 +3,5 @@
     "prefix": "iron-doc-viewer"
     "body": """
     <iron-doc-viewer descriptor="{{${1:elementDescriptor}}}"></iron-doc-viewer>
+    $0
     """

--- a/snippets/iron-icon.cson
+++ b/snippets/iron-icon.cson
@@ -2,5 +2,6 @@
   "iron icon":
     "prefix": "iron-icon"
     "body": """
-    <iron-icon icon="$0"></iron-icon>
+    <iron-icon icon="$1"></iron-icon>
+    $0
     """

--- a/snippets/iron-iconset.cson
+++ b/snippets/iron-iconset.cson
@@ -5,4 +5,5 @@
     <iron-iconset name="${1:my-icons}" src="${2:my-icons.png}" width="${3:96}" size="${4:24}"
         icons="${5:location place starta stopb bus car train walk}">
     </iron-iconset>
+    $0
     """

--- a/snippets/iron-image.cson
+++ b/snippets/iron-image.cson
@@ -3,4 +3,5 @@
     "prefix": "iron-image"
     "body": """
     <iron-image src="$1" ${2:preload} sizing="${3:cover}"></iron-image>
+    $0
     """

--- a/snippets/iron-input.cson
+++ b/snippets/iron-input.cson
@@ -2,5 +2,6 @@
   "iron input":
     "prefix": "iron-input"
     "body": """
-      <input is="iron-input" bind-value="{{${1:myValue}}}">
+    <input is="iron-input" bind-value="{{${1:myValue}}}">
+    $0
     """

--- a/snippets/iron-jsonp-library.cson
+++ b/snippets/iron-jsonp-library.cson
@@ -6,4 +6,5 @@
       library-url="${1}"
       notify-event="${2}"
       library-loaded="${3}"></iron-jsonp-library>
+    $0
     """

--- a/snippets/iron-localstorage.cson
+++ b/snippets/iron-localstorage.cson
@@ -2,5 +2,6 @@
   "iron localstorage":
     "prefix": "iron-localstorage"
     "body": """
-      <iron-localstorage name="${1:my-app-storage}" value="{{${0:value}}}"></iron-localstorage>
+    <iron-localstorage name="${1:my-app-storage}" value="{{${2:value}}}"></iron-localstorage>
+    $0
     """

--- a/snippets/iron-media-query.cson
+++ b/snippets/iron-media-query.cson
@@ -4,4 +4,5 @@
     "body": """
     <iron-media-query query="${1:min-width: 640px}" query-matches="{{${2:largeScreen}}}">
     </iron-media-query>
+    $0
     """

--- a/snippets/iron-meta.cson
+++ b/snippets/iron-meta.cson
@@ -3,4 +3,5 @@
     "prefix": "iron-meta"
     "body": """
     <iron-meta key="${1:info}"></iron-meta>
+    $0
     """

--- a/snippets/iron-pages.cson
+++ b/snippets/iron-pages.cson
@@ -7,4 +7,5 @@
       <section>$3</section>
       <section>$4</section>
     </iron-pages>
+    $0
     """

--- a/snippets/paper-autogrow-textarea.cson
+++ b/snippets/paper-autogrow-textarea.cson
@@ -3,6 +3,7 @@
     "prefix": "paper-autogrow-textarea"
     "body": """
     <paper-autogrow-textarea id="${1:a1}">
-      <textarea id="${2:t1}"></textarea>
+      <textarea id="${2:t1}">$3</textarea>
     <paper-autogrow-textarea>
+    $0
     """

--- a/snippets/paper-button.cson
+++ b/snippets/paper-button.cson
@@ -2,5 +2,6 @@
   "paper button":
     "prefix": "paper-button"
     "body": """
-    <paper-button${1: raised}>$0</paper-button>
+    <paper-button${1: raised}>$2</paper-button>
+    $0
     """

--- a/snippets/paper-checkbox.cson
+++ b/snippets/paper-checkbox.cson
@@ -3,4 +3,5 @@
     "prefix": "paper-checkbox"
     "body": """
     <paper-checkbox${1: checked}></paper-checkbox>
+    $0
     """

--- a/snippets/paper-fab.cson
+++ b/snippets/paper-fab.cson
@@ -3,4 +3,5 @@
     "prefix": "paper-fab"
     "body": """
     <paper-fab icon="${1:add}"></paper-fab>
+    $0
     """

--- a/snippets/paper-input.cson
+++ b/snippets/paper-input.cson
@@ -2,5 +2,6 @@
   "paper input":
     "prefix": "paper-input"
     "body": """
-    <paper-input label="$0"></paper-input>
+    <paper-input label="$1"></paper-input>
+    $0
     """

--- a/snippets/paper-item.cson
+++ b/snippets/paper-item.cson
@@ -2,5 +2,6 @@
   "paper item":
     "prefix": "paper-item"
     "body": """
-    <paper-item>$0</paper-item>
+    <paper-item>$1</paper-item>
+    $0
     """

--- a/snippets/paper-menu.cson
+++ b/snippets/paper-menu.cson
@@ -3,7 +3,8 @@
     "prefix": "paper-menu"
     "body": """
     <paper-menu${1: multi}>
-      <paper-item>Item 1</paper-item>
-      <paper-item>Item 2</paper-item>
+      <paper-item>${2:Item 1}</paper-item>
+      <paper-item>${3:Item 2}</paper-item>
     </paper-menu>
+    $0
     """

--- a/snippets/paper-progress.cson
+++ b/snippets/paper-progress.cson
@@ -3,4 +3,5 @@
     "prefix": "paper-progress"
     "body": """
     <paper-progress value="${1:10}"></paper-progress>
+    $0
     """

--- a/snippets/paper-radio-button.cson
+++ b/snippets/paper-radio-button.cson
@@ -3,4 +3,5 @@
     "prefix": "paper-radio-button"
     "body": """
     <paper-radio-button></paper-radio-button>
+    $0
     """

--- a/snippets/paper-radio-group.cson
+++ b/snippets/paper-radio-group.cson
@@ -7,4 +7,5 @@
       <paper-radio-button name="${4:medium}">${5:Medium}</paper-radio-button>
       <paper-radio-button name="${6:large}">${7:Large}</paper-radio-button>
     </paper-radio-group>
+    $0
     """

--- a/snippets/paper-ripple.cson
+++ b/snippets/paper-ripple.cson
@@ -3,4 +3,5 @@
     "prefix": "paper-ripple"
     "body": """
     <paper-ripple></paper-ripple>
+    $0
     """

--- a/snippets/paper-scroll-header-panel.cson
+++ b/snippets/paper-scroll-header-panel.cson
@@ -8,4 +8,5 @@
       </paper-toolbar>
       <div>${3:Page content}</div>
     </paper-scroll-header-panel>
+    $0
     """

--- a/snippets/paper-slider.cson
+++ b/snippets/paper-slider.cson
@@ -3,4 +3,5 @@
     "prefix": "paper-slider"
     "body": """
     <paper-slider min="${1:10}" max="${2:200}" value="${3:110}"></paper-slider>
+    $0
     """

--- a/snippets/paper-spinner.cson
+++ b/snippets/paper-spinner.cson
@@ -3,4 +3,5 @@
     "prefix": "paper-spinner"
     "body": """
     <paper-spinner${1: active}></paper-spinner>
+    $0
     """

--- a/snippets/paper-tab.cson
+++ b/snippets/paper-tab.cson
@@ -2,5 +2,6 @@
   "paper tab":
     "prefix": "paper-tab"
     "body": """
-    <paper-tab>$0</paper-tab>
+    <paper-tab>$1</paper-tab>
+    $0
     """

--- a/snippets/paper-tabs.cson
+++ b/snippets/paper-tabs.cson
@@ -7,4 +7,5 @@
       <paper-tab>${3:TAB 2}</paper-tab>
       <paper-tab>${4:TAB 3}</paper-tab>
     </paper-tabs>
+    $0
     """

--- a/snippets/paper-toast.cson
+++ b/snippets/paper-toast.cson
@@ -2,5 +2,6 @@
   "paper toast":
     "prefix": "paper-toast"
     "body": """
-    <paper-toast text="${1:Your draft has been discarded.}">$0</paper-toast>
+    <paper-toast text="${1:Your draft has been discarded.}">$2</paper-toast>
+    $0
     """

--- a/snippets/paper-toggle-button.cson
+++ b/snippets/paper-toggle-button.cson
@@ -3,4 +3,5 @@
     "prefix": "paper-toggle-button"
     "body": """
     <paper-toggle-button${1: checked}></paper-toggle-button>
+    $0
     """

--- a/snippets/paper-toolbar.cson
+++ b/snippets/paper-toolbar.cson
@@ -3,6 +3,7 @@
     "prefix": "paper-toolbar"
     "body": """
     <paper-toolbar class="${1:tall}">
-      $0
+      $2
     </paper-toolbar>
+    $0
     """

--- a/snippets/webcomponentsjs.cson
+++ b/snippets/webcomponentsjs.cson
@@ -2,5 +2,6 @@
   "web components polyfill":
     "prefix": "webcomponents"
     "body": """
-    <script src="${0:bower_components}/webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="${1:bower_components}/webcomponentsjs/webcomponents-lite.js"></script>
+    $0
     """


### PR DESCRIPTION
When a snippet is placed and the user has finished tabbing through all options, some elements were (the google-\* elements) and some elements weren't (most iron-\* and paper-\* elements) correctly anchoring after the element.

This pull request makes sure that if you tab after every option, you land on a new line after the element.
